### PR TITLE
Convert between the API implictily absolute and DO standard record names

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package digitalocean
 import (
 	"context"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -39,7 +40,7 @@ func (p *Provider) getDNSEntries(ctx context.Context, zone string) ([]libdns.Rec
 
 		for _, entry := range domains {
 			record := libdns.Record{
-				Name:  entry.Name,
+				Name:  entry.Name + "." + strings.Trim(zone, ".") + ".",
 				Value: entry.Data,
 				Type:  entry.Type,
 				TTL:   time.Duration(entry.TTL) * time.Second,
@@ -72,7 +73,7 @@ func (p *Provider) addDNSEntry(ctx context.Context, zone string, record libdns.R
 	p.getClient()
 
 	entry := godo.DomainRecordEditRequest{
-		Name: record.Name,
+		Name: strings.Trim(strings.ReplaceAll(record.Name, zone, ""), "."),
 		Data: record.Value,
 		Type: record.Type,
 		TTL:  int(record.TTL.Seconds()),
@@ -118,7 +119,7 @@ func (p *Provider) updateDNSEntry(ctx context.Context, zone string, record libdn
 	}
 
 	entry := godo.DomainRecordEditRequest{
-		Name: record.Name,
+		Name: strings.Trim(strings.ReplaceAll(record.Name, zone, ""), "."),
 		Data: record.Value,
 		Type: record.Type,
 		TTL:  int(record.TTL.Seconds()),


### PR DESCRIPTION
Previously, this DNS provider incorrectly assumed that DNS records
passed to it followed the standard notation, used by the DigitalOcean
API, that absolute DNS record names end with a dot, and relative DNS
record names don't.

This is incorrect because libdns uses de-facto implicitly absolute DNS
record names with a dot suffix, which causes any DNS record added with
eg certmagic to incorrectly be treated as relative, resulting in records
like: _acme-challenge.example.org.example.org

This fixes this issue by converting between the standard dot-suffix DNS
record name notation used by the DigitalOcean API and the implicitly
absolute record names used by libdns.

See: https://github.com/libdns/libdns/issues/12