### PR TITLE
Revert "Convert between the API implictily absolute and DO standard record names"

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,7 +3,6 @@ package digitalocean
 import (
 	"context"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -40,7 +39,7 @@ func (p *Provider) getDNSEntries(ctx context.Context, zone string) ([]libdns.Rec
 
 		for _, entry := range domains {
 			record := libdns.Record{
-				Name:  entry.Name + "." + strings.Trim(zone, ".") + ".",
+				Name:  entry.Name,
 				Value: entry.Data,
 				Type:  entry.Type,
 				TTL:   time.Duration(entry.TTL) * time.Second,
@@ -73,7 +72,7 @@ func (p *Provider) addDNSEntry(ctx context.Context, zone string, record libdns.R
 	p.getClient()
 
 	entry := godo.DomainRecordEditRequest{
-		Name: strings.Trim(strings.ReplaceAll(record.Name, zone, ""), "."),
+		Name: record.Name,
 		Data: record.Value,
 		Type: record.Type,
 		TTL:  int(record.TTL.Seconds()),
@@ -119,7 +118,7 @@ func (p *Provider) updateDNSEntry(ctx context.Context, zone string, record libdn
 	}
 
 	entry := godo.DomainRecordEditRequest{
-		Name: strings.Trim(strings.ReplaceAll(record.Name, zone, ""), "."),
+		Name: record.Name,
 		Data: record.Value,
 		Type: record.Type,
 		TTL:  int(record.TTL.Seconds()),


### PR DESCRIPTION
This reverts commit bac007bf507194c1629657a31095830eb7816ecd.

In https://github.com/libdns/libdns/pull/28, it was decided to use relative names in Record.Name.